### PR TITLE
update name of linter job

### DIFF
--- a/.github/workflows/c-linter-check.yml
+++ b/.github/workflows/c-linter-check.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 jobs:
-  job-python-linter:
+  job-c-linter:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Please fill in this pull request template before submitting 

### 1. This pull request resolves #38 

### 2. Description
Change name of job to run C linting. Was incorrectly called as a python job.
